### PR TITLE
텍스처 최적화 시 품질 저하 문제 개선

### DIFF
--- a/Application/Views/TextureOptimization.xaml
+++ b/Application/Views/TextureOptimization.xaml
@@ -36,7 +36,7 @@
                         x:Name="OptimizeSize"
                         Title="Optimize Size"
                         Description="Width + Height in px = Optimize size. If nothing is optimized,&#10;try to set less values(4096, 2048, 1024, 512)"
-                        NumberValue="8192"
+                        NumberValue="2048"
                         PropertyChanged="OptimizeSize_PropertyChanged"/>
                 </StackPanel>
 
@@ -46,7 +46,7 @@
                         Title="Downsize"
                         Description="If enabled, the size of textures will be reduced by 2 times."
                         PropertyChanged="Downsize_PropertyChanged"
-                        IsToogled="True"/>
+                        IsToogled="False"/>
                 </StackPanel>
 
                 <StackPanel Margin="0 10 0 0">

--- a/Application/Views/TextureOptimization.xaml.cs
+++ b/Application/Views/TextureOptimization.xaml.cs
@@ -11,9 +11,9 @@ namespace ToolKitV.Views
     {
         public string MainPath { get; set; } = "";
         public string BackupPath { get; set; } = "";
-        public string OptimizeSizeValue { get; set; } = "8192";
+        public string OptimizeSizeValue { get; set; } = "2048";
         public bool OnlyOverSizedToogled { get; set; } = false;
-        public bool DownSizeValue { get; set; } = true;
+        public bool DownSizeValue { get; set; } = false;
         public bool FormatOptimizeValue { get; set; } = false;
         public TextureOptimization()
         {
@@ -130,11 +130,6 @@ namespace ToolKitV.Views
 
         private async void OptimizeButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!DownSizeValue && !FormatOptimizeValue)
-            {
-                return;
-            }
-
             OptimizeButton.IsButtonEnabled = false;
             AnalyzeButton.IsButtonEnabled = false;
             OptimizeButton.Title = "In progress...";


### PR DESCRIPTION
## 변경 사항

### 최적화 알고리즘 개선
- mipmap 레벨 계산 방식 변경 (maxLevel - 2로 보수적 접근)
- 재압축 필요 여부 사전 체크하여 불필요한 처리 제거
- BC7 포맷 유지로 고품질 텍스처 보존

### 기본 설정 변경
- Downsize 기본값: true → false (해상도 유지)
- Optimize Size 기본값: 8192 → 2048 (더 많은 텍스처 처리)
- 품질 우선 정책으로 전환

### 영향
- 파일 크기: 약 20-40% 감소 (기존 75% 대비 완화)
- 품질 손실: 최소화 (해상도 유지)
- 스트리밍 이슈: 해결 (16MB 미만)

## 테스트 환경
- FiveM 서버 (600+ 커스텀 스킨)
- 16MB 이상 텍스처 파일

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  - 텍스처 최적화 처리 흐름 개선으로 불필요한 재처리 과정 제거 및 성능 향상

* **변경사항**
  - 기본 최적화 크기 설정값 8192에서 2048로 변경
  - 다운사이징 토글 기본값을 활성화에서 비활성화로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->