### PR TITLE
빌드 시 CodeWalker.Core.dll 복사 누락 문제 수정

### DIFF
--- a/Application/ToolKitV.csproj
+++ b/Application/ToolKitV.csproj
@@ -135,6 +135,9 @@
     <None Update="Dependencies\texconv.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Dependencies\CodeWalker.Core.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Libraries\texconv.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## 문제
빌드 후 실행 파일을 실행했을 때 폴더를 선택하고 최적화 버튼을 눌러도 무반응인 문제가 발생했습니다. 원인은 CodeWalker.Core.dll이 빌드 출력 디렉토리에 복사되지 않았기 때문입니다.

## 해결 방법
ToolKitV.csproj에 CodeWalker.Core.dll을 빌드 출력 디렉토리에 자동으로 복사하는 설정을 추가했습니다.

## 변경 사항
- `Dependencies\CodeWalker.Core.dll`에 `CopyToOutputDirectory: Always` 설정 추가

## 테스트 방법
1. Visual Studio에서 솔루션 빌드
2. bin\Debug\net6.0-windows\ 폴더에 Dependencies\CodeWalker.Core.dll 존재 확인
3. 실행 파일 실행 후 폴더 선택 및 최적화 기능 동작 확인

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 빌드 구성 및 의존성 관리 개선에 관한 내부 변경사항입니다. 사용자에게 직접적으로 보이는 새로운 기능, 버그 수정, 또는 인터페이스 변경은 없습니다.

* **Chores**
  * 빌드 출력 디렉토리 구성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->