### PR TITLE
Release 빌드 직접 실행 가능하도록 수정

### DIFF
--- a/Application/App.xaml.cs
+++ b/Application/App.xaml.cs
@@ -11,29 +11,13 @@ namespace ToolKitV
         {
             Mutex = new Mutex(true, ResourceAssembly.GetName().Name);
 
-            bool canStart = false;
-
-#if DEBUG
-            canStart = true;
-#else
-            for (int i = 0; i != e.Args.Length; ++i)
-            {
-                if (e.Args[i] == "-startedFromUpdater")
-                {
-                    canStart = true;
-                    break;
-                }
-            }
-#endif
-            if (!Mutex.WaitOne(0, false) || !canStart)
+            if (!Mutex.WaitOne(0, false))
             {
                 Current.Shutdown();
                 return;
             }
-            else
-            {
-                ShutdownMode = ShutdownMode.OnLastWindowClose;
-            }
+
+            ShutdownMode = ShutdownMode.OnLastWindowClose;
             base.OnStartup(e);
         }
 
@@ -54,7 +38,7 @@ namespace ToolKitV
 
         void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
-            MessageBox.Show("Error message:\n" + e.Exception.Message + "\n\nIf you need help, write to our discord.\nOur site: umbrella.re", "ToolKitV Crash", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show("오류 메시지:\n" + e.Exception.Message + "\n\n도움이 필요하시면 디스코드로 문의해주세요.\nDiscord: discord.gg/VzHq5ysheb", "시바서버 텍스처 최적화 오류", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 }

--- a/Application/Views/Credits.xaml.cs
+++ b/Application/Views/Credits.xaml.cs
@@ -6,7 +6,7 @@ namespace ToolKitV.Views
 {
     public partial class Credits : UserControl
     {
-        private readonly string DiscordUrl = "https://discord.gg/sibaserver";
+        private readonly string DiscordUrl = "https://discord.gg/VzHq5ysheb";
         private readonly string SiteUrl = "https://github.com/Jeong-Ryeol/ToolKitV";
         public string Version { get; set; } = "";
         public Credits()


### PR DESCRIPTION
## 문제
Release 빌드에서 exe 파일을 직접 실행하면 바로 종료되는 문제가 있었습니다. 원인은 App.xaml.cs에서 업데이터를 통해서만 실행되도록 `-startedFromUpdater` 인수를 강제했기 때문입니다.

## 해결 방법
업데이터 인수 체크를 제거하고 직접 실행할 수 있도록 수정했습니다.

## 변경 사항
- 업데이터 필수 인수 제거 (중복 실행 방지는 유지)
- 오류 다이얼로그 메시지 한글화
- Discord 링크를 시바서버 링크로 변경 (discord.gg/VzHq5ysheb)

## 테스트 방법
1. Release 빌드 후 exe 파일 직접 실행
2. 프로그램이 정상적으로 실행되는지 확인

Closes #9